### PR TITLE
Correction des erreurs de compilation XAML

### DIFF
--- a/CreditManagement100/Features/Common/ModuleUnderDevelopmentPage.xaml
+++ b/CreditManagement100/Features/Common/ModuleUnderDevelopmentPage.xaml
@@ -38,9 +38,21 @@
                     
                     <!-- Animated dots -->
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,16">
-                        <Ellipse x:Name="Dot1" Width="12" Height="12" Fill="{ThemeResource PrimaryBrush}" Margin="4"/>
-                        <Ellipse x:Name="Dot2" Width="12" Height="12" Fill="{ThemeResource PrimaryLightBrush}" Margin="4"/>
-                        <Ellipse x:Name="Dot3" Width="12" Height="12" Fill="{ThemeResource Gray2Brush}" Margin="4"/>
+                        <Ellipse x:Name="Dot1" Width="12" Height="12" Fill="{ThemeResource PrimaryBrush}" Margin="4">
+                            <Ellipse.RenderTransform>
+                                <TranslateTransform/>
+                            </Ellipse.RenderTransform>
+                        </Ellipse>
+                        <Ellipse x:Name="Dot2" Width="12" Height="12" Fill="{ThemeResource PrimaryLightBrush}" Margin="4">
+                            <Ellipse.RenderTransform>
+                                <TranslateTransform/>
+                            </Ellipse.RenderTransform>
+                        </Ellipse>
+                        <Ellipse x:Name="Dot3" Width="12" Height="12" Fill="{ThemeResource Gray2Brush}" Margin="4">
+                            <Ellipse.RenderTransform>
+                                <TranslateTransform/>
+                            </Ellipse.RenderTransform>
+                        </Ellipse>
                         
                         <StackPanel.Resources>
                             <Storyboard x:Name="BounceDotsStoryboard" RepeatBehavior="Forever">
@@ -69,11 +81,6 @@
                                     BeginTime="0:0:0.4"/>
                             </Storyboard>
                         </StackPanel.Resources>
-                        
-                        <!-- Set transform for dots -->
-                        <Ellipse.RenderTransform>
-                            <TranslateTransform/>
-                        </Ellipse.RenderTransform>
                     </StackPanel>
                     
                     <!-- Module title and message -->

--- a/CreditManagement100/Features/Shell/ShellPage.xaml
+++ b/CreditManagement100/Features/Shell/ShellPage.xaml
@@ -87,12 +87,10 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
 
-                <!-- User Icon -->
-                <Ellipse Grid.Column="0" Width="32" Height="32" Fill="{ThemeResource PrimaryLightBrush}">
-                    <Ellipse.OpacityMask>
-                        <ImageBrush ImageSource="/Assets/user_icon.png"/>
-                    </Ellipse.OpacityMask>
-                </Ellipse>
+                <!-- User Icon - Remplacer OpacityMask par un FontIcon plus simple -->
+                <Grid Grid.Column="0" Width="32" Height="32" Background="{ThemeResource PrimaryLightBrush}" CornerRadius="16">
+                    <FontIcon Glyph="&#xE77B;" FontSize="16" Foreground="White"/>
+                </Grid>
 
                 <!-- User Name and Role -->
                 <StackPanel 


### PR DESCRIPTION
## Description
Cette PR corrige deux erreurs de compilation XAML :

1. Dans `ShellPage.xaml` : La propriété `OpacityMask` n'est pas disponible pour l'élément `Ellipse`. J'ai remplacé l'icône d'utilisateur par un élément `Grid` avec `CornerRadius` et un `FontIcon`.

2. Dans `ModuleUnderDevelopmentPage.xaml` : La propriété `RenderTransform` était incorrectement attachée au `StackPanel` au lieu des éléments `Ellipse` individuels. J'ai déplacé les transformations pour les attacher directement à chaque Ellipse.

## Erreurs résolues
```
1>C:\...\ShellPage.xaml(92,22): XamlCompiler error WMC0011: Unknown member 'OpacityMask' on element 'Ellipse'
1>C:\...\ModuleUnderDevelopmentPage.xaml(74,26): XamlCompiler error WMC0010: Unknown attachable member 'Ellipse.RenderTransform' on element 'StackPanel'
```

## Issue liée
Fixes #7